### PR TITLE
Bump scalacheck/specs2 version

### DIFF
--- a/.versions.json
+++ b/.versions.json
@@ -1,3 +1,3 @@
 {
-  "precog-tectonic": "12.0.13"
+  "precog-tectonic": "12.0.13-0e07154"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,10 +5,10 @@ import sbt._
 object Dependencies {
   private val predefVersion     = "0.1.2"
   private val scalazVersion     = "7.2.30"
-  private val scalacheckVersion = "1.14.3"
+  private val scalacheckVersion = "1.15.4"
   private val scodecVersion     = "1.11.7"
   private val spireVersion      = "0.17.0"
-  private val specsVersion      = "4.10.5"
+  private val specsVersion      = "4.10.6"
   private val jawnVersion       = "1.0.0"
 
   def core = Seq(


### PR DESCRIPTION
Otherwise we get binary incompatible 1.14 scalacheck in mimir, breaking the test suite.